### PR TITLE
Build libqd as a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories("${PROJECT_SOURCE_DIR}")
 set(qd_sources "threadid.cpp")
 set(lock_sources locks/mcs_lock.cpp locks/mcs_futex_lock.cpp)
 
-add_library(qd ${qd_sources} ${lock_sources})
+add_library(qd SHARED ${qd_sources} ${lock_sources})
 
 option(QD_USE_LIBNUMA
 	"Use libnuma to determine NUMA structure" ON)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ int main() {
 To compile and run a program it may be required to add `/usr/local/include/` to your include path and `/usr/local/lib` to your library path.
 Compiling and running should then work using
 ```
-g++ -I/usr/local/include/qd/ -L/usr/local/lib/ myprogram.cpp -pthread -lqd -o myprogram
+g++ -I/usr/local/include/qd/ -L/usr/local/lib/ -Wl,-rpath=/usr/local/lib/ myprogram.cpp -pthread -lqd -o myprogram
 ./myprogram
 ```
 


### PR DESCRIPTION
This PR changes the QD library from static to shared in order to facilitate linking by other shared libraries.
The readme usage example is also updated to reflect that there may be a need to specify the rpath pointing to the library upon linking. 