### PR TITLE
Fix signed comparison of queue size

### DIFF
--- a/queues/buffer_queue.hpp
+++ b/queues/buffer_queue.hpp
@@ -12,10 +12,10 @@
  * @brief a buffer-based tantrum queue
  * @tparam ARRAY_SIZE the buffer's size in bytes
  */
-template<long ARRAY_SIZE>
+template<unsigned long ARRAY_SIZE>
 class buffer_queue {
 	/** type for sizes of queue entries */
-	typedef long s_type;
+	typedef unsigned long s_type;
 	/** type for the size field for queue entries, loads must not be optimized away in flush */
 	typedef std::atomic<s_type> sizetype;
 


### PR DESCRIPTION
Newer versions of compilers complain about the following when building with DEBUG:

```
queues/buffer_queue.hpp:122:13: error: comparison of integer expressions of different signedness:
  ‘buffer_queue<262139>::s_type’ {aka ‘long int’} and ‘long unsigned int’ [-Werror=sign-compare]
      if(todo >= static_cast<s_type>(ARRAY_SIZE)-sizeof(std::atomic<int>)) { /* queue closed */
```
Fix this by declaring sizes as unsigned.