### PR TITLE
Cleanup examples

### DIFF
--- a/examples/counter/cs.cpp
+++ b/examples/counter/cs.cpp
@@ -1,3 +1,5 @@
+#include "cs.hpp"
+
 #include<chrono>
 #include<iostream>
 

--- a/examples/counter/cs_atomic.cpp
+++ b/examples/counter/cs_atomic.cpp
@@ -1,6 +1,4 @@
 #include<atomic>
-#include<iostream>
-
 #include<chrono>
 #include<iostream>
 


### PR DESCRIPTION
It's a good idea to include the corresponding header file,
but having multiple includes of the same header file is redundant.