### PR TITLE
Add a cpplint GitHub action

### DIFF
--- a/.github/workflows/cpplint.yml
+++ b/.github/workflows/cpplint.yml
@@ -4,7 +4,7 @@ jobs:
   cpplint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
     - run: pip install cpplint
     - run: cpplint --filter=-build,-legal,-readability,-runtime/explicit,-runtime/int,-runtime/references,-whitespace --exclude=tests --recursive .


### PR DESCRIPTION
Currently with most checks disabled, except from some runtime checks
that are currently satisfied by the code base.  The idea is to use
this action and gradually enable the checks that we like when these
are fixed, and leave the ones that for whatever reason we do not like
disabled.